### PR TITLE
fix: test-connection endpoint now supports Moonraker, PrusaLink, Elegoo

### DIFF
--- a/frontend/src/pages/Printers.jsx
+++ b/frontend/src/pages/Printers.jsx
@@ -395,9 +395,14 @@ function PrinterModal({ isOpen, onClose, onSubmit, printer, onSyncAms }) {
   }, [printer, isOpen])
 
   const handleTestConnection = async () => {
-    if (!formData.api_host || !formData.serial || !formData.access_code) {
+    if (!formData.api_host) {
       setTestStatus('error')
-      setTestMessage('Please fill in IP, Serial, and Access Code')
+      setTestMessage('Please fill in the IP address')
+      return
+    }
+    if (formData.api_type === 'bambu' && (!formData.serial || !formData.access_code)) {
+      setTestStatus('error')
+      setTestMessage('Please fill in Serial and Access Code')
       return
     }
     


### PR DESCRIPTION
The Printers page test-connection flow was hardcoded for Bambu only, blocking Kobra S1 and other non-Bambu printers from being tested post-setup. Frontend validation required serial/access_code for all types; backend rejected non-Bambu with HTTP 400.

https://claude.ai/code/session_01SB8dxJt3Q8B3u2kR3usDR6