### PR TITLE
fix: invoice download fails with ERR_HTTP2_PROTOCOL_ERROR

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -7896,10 +7896,14 @@ def get_order_invoice(
     gen = InvoiceGenerator(branding, enriched.model_dump())
     pdf_bytes = gen.generate()
 
-    return StreamingResponse(
-        iter([pdf_bytes]),
+    from fastapi.responses import Response
+    return Response(
+        content=pdf_bytes,
         media_type="application/pdf",
-        headers={"Content-Disposition": f"attachment; filename=invoice_{order.order_number or order.id}.pdf"}
+        headers={
+            "Content-Disposition": f"attachment; filename=invoice_{order.order_number or order.id}.pdf",
+            "Content-Length": str(len(pdf_bytes)),
+        }
     )
 
 


### PR DESCRIPTION
Replace StreamingResponse(iter([pdf_bytes])) with Response(content=pdf_bytes) and add Content-Length header. The missing Content-Length broke HTTP/2 framing, causing the browser to abort the download.

https://claude.ai/code/session_01SB8dxJt3Q8B3u2kR3usDR6