### PR TITLE
feat: auto-discover cameras for all printer types, not just Bambu

### DIFF
--- a/backend/elegoo_adapter.py
+++ b/backend/elegoo_adapter.py
@@ -390,6 +390,27 @@ class ElegooPrinter:
             log.warning(f"SDCP command {cmd} failed: {e}")
             return False
 
+    def get_webcam_url(self) -> Optional[str]:
+        """Discover camera stream URL for Elegoo FDM printers.
+
+        Neptune 4 / Centauri Carbon expose an MJPEG stream on port 8080.
+        Resin printers (Saturn) typically have no camera.
+        """
+        import requests as _req
+        # Common camera endpoints for Elegoo FDM printers
+        candidates = [
+            f"http://{self.host}:8080/?action=stream",
+            f"http://{self.host}:8080/webcam/?action=stream",
+        ]
+        for url in candidates:
+            try:
+                resp = _req.head(url, timeout=3)
+                if resp.status_code == 200:
+                    return url
+            except Exception:
+                continue
+        return None
+
     def pause_print(self) -> bool:
         """Pause current print (Cmd 129)."""
         return self._send_command(SDCPCommand.PAUSE_PRINT)


### PR DESCRIPTION
- Moonraker (Kobra/Rinkhals): call get_webcam_urls() after connect and save stream URL to DB via printer_events.discover_camera()
- PrusaLink (Prusa MK4/XL/etc): add get_webcam_url() that probes /api/v1/cameras and /webcam/?action=snapshot
- Elegoo (Neptune 4/Centauri): add get_webcam_url() that probes MJPEG stream on port 8080
- Fix get_camera_url() in main.py to only auto-generate RTSP for Bambu, letting other types use their discovered camera_url field
- Add proper error handling to PDF invoice endpoint so failures return a meaningful error message instead of generic 500

https://claude.ai/code/session_01SB8dxJt3Q8B3u2kR3usDR6