### PR TITLE
fix: transcode MJPEG camera streams via ffmpeg for WebRTC compatibility

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -5243,7 +5243,12 @@ def sync_go2rtc_config(db: Session):
     for p in printers:
         url = get_camera_url(p)
         if url:
-            streams[f"printer_{p.id}"] = url
+            # HTTP streams (MJPEG) need ffmpeg transcoding to H264 for WebRTC;
+            # RTSP streams already carry H264 and can be proxied directly.
+            if url.startswith(("http://", "https://")):
+                streams[f"printer_{p.id}"] = f"ffmpeg:{url}#video=h264"
+            else:
+                streams[f"printer_{p.id}"] = url
             # Save generated URL back to DB if not already set
             if not p.camera_url and url:
                 p.camera_url = url


### PR DESCRIPTION
Kobra/Moonraker cameras output MJPEG which cannot be negotiated over WebRTC (requires H264/VP8). Prefix HTTP camera URLs with ffmpeg:#video=h264 in go2rtc config so streams are transcoded. RTSP streams (Bambu) pass through directly as they already carry H264.

https://claude.ai/code/session_01SB8dxJt3Q8B3u2kR3usDR6